### PR TITLE
fix: correct maoxuan agent install command

### DIFF
--- a/daily-digests/2026-07-10/maoxuan-product-agent.md
+++ b/daily-digests/2026-07-10/maoxuan-product-agent.md
@@ -46,8 +46,8 @@ Automated review identified **Mermaid.js** as a key module contributing to infra
 
 ## Installation
 ```bash
-# Install instruction (default)
-pip install -r requirements.txt
+# Install for Codex, Claude Code, and Cursor
+npx skills add atdy/maoxuan-product-agent --skill product-decision-agent --agent codex claude-code cursor -g -y
 ```
 
 ## Related Vault Entries


### PR DESCRIPTION
## Description

The generated Maoxuan Product Agent digest currently recommends `pip install -r requirements.txt`, but the source repository has no `requirements.txt` and is distributed as an Agent Skill rather than a Python package.

This replaces only that installation snippet with the upstream command for Codex, Claude Code, and Cursor. The quality score, tags, classification, and summary are unchanged.

## Validation

- `npx --yes skills add atdy/maoxuan-product-agent --list` cloned the repository and found exactly one installable skill: `product-decision-agent`
- confirmed the source repository has no root `requirements.txt`
- `git diff --cached --check` passed

## Checklist

- [x] I did not add private or paywalled content.
- [x] I preserved source URLs.
- [x] I did not add secrets, tokens, or `.env` files.
- [x] I kept the resource in its existing category.
- [x] No generated index change is needed for this focused text correction.
- [x] I checked formatting.
